### PR TITLE
BookshelfAdapter isn't being exported correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ BookshelfAdapter.prototype.destroy = function(doc, Model, cb) {
 };
 
 var adapter = new BookshelfAdapter();
-module.exports.BookshelfAdapter = BookshelfAdapter;
+
 module.exports = function(models) {
   if (models) {
     for (var i = 0; i < models.length; i++) {
@@ -26,3 +26,5 @@ module.exports = function(models) {
     factory.setAdapter(adapter);
   }
 };
+
+module.exports.BookshelfAdapter = BookshelfAdapter;


### PR DESCRIPTION
Hi,

I ran into an issue where `BookshelfAdapter` wasn't being exported correctly. Looking at the code, `BookshelfAdapter` is being tacked onto `module.exports` but then `module.exports` is immediately overwritten with the anonymous `function`, leaving BookshelfAdapter inaccessible.
