### PR TITLE
Fixes #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ BookshelfAdapter.prototype.set = function(props, doc, Model) {
   return doc.set(props);
 };
 BookshelfAdapter.prototype.save = function(doc, Model, cb) {
-  doc.save().nodeify(cb);
+  doc.save(null, { method: 'insert' }).nodeify(cb);
 };
 BookshelfAdapter.prototype.destroy = function(doc, Model, cb) {
   if (!doc.id) return process.nextTick(cb);


### PR DESCRIPTION
Can now specify an id in a factory, and have the factory insert a record into the database.
Before, it would try to update a record by that id, and we would see an error like "[CustomError: No Rows Updated] message: "No Rows Updated""
